### PR TITLE
Render new-style URLs for devportal API access

### DIFF
--- a/devportal.yaml
+++ b/devportal.yaml
@@ -1,2 +1,2 @@
 ## This file specifies contract version between dev portal and go templates
-version: 1
+version: 2

--- a/fragments/swagger.gohtml
+++ b/fragments/swagger.gohtml
@@ -7,7 +7,7 @@
 <span id="swagger-ui"></span>
 <script>
  const ui = SwaggerUIBundle({
-     url: "/openapi/services/{{.CurrentNamespace}}/{{.CurrentService}}/openapi.json",
+     url: "{{.Prefix}}/api/v2/services/{{.CurrentNamespace}}/{{.CurrentService}}/openapi.json",
      dom_id: '#swagger-ui',
      presets: [
          SwaggerUIBundle.presets.apis,


### PR DESCRIPTION
Merging this PR will break customers that have old devportal code.
Users need to update to a versiont hat includes https://github.com/datawire/apro/pull/482 .
The information I have is there are no customers using devportal, yet.