### PR TITLE
Fix swagger preset 404

### DIFF
--- a/fragments/swagger.gohtml
+++ b/fragments/swagger.gohtml
@@ -1,6 +1,6 @@
 {{define "swagger-head"}}
     <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
-    <script src="https://unpkg.com/swagger-ui-dist@3/swagger-standalone-preset.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-standalone-preset.js"></script>
     <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3/swagger-ui.css" >
     <link rel="stylesheet" type="text/css" href="{{.Prefix}}styles/components/swagger.css" >
 {{end}}


### PR DESCRIPTION
It's `swagger-ui-standalone-preset.js`, not `swagger-standalone-preset.js`.

Tested by:

- deploy an Ambassador
- open $AMBASSADOR_IP/docs/ in a browser
- pick an API with some docs
- click on its docs
- open Chrome developer tools "Network" pane and observe that `swagger-ui-standalone-presets.js` loads with a 200

I suppose we could also just delete it, but if we're gonna have it, let's use the correct name...